### PR TITLE
caching _build and deps directories for faster travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ elixir:
   - 1.4.1
 addons:
   postgresql: '9.4'
+cache:
+  directories:
+    - _build
+    - deps
 env:
   - MIX_ENV=test
 before_script:


### PR DESCRIPTION
Caching speeds up travis, see here: https://dockyard.com/blog/2015/12/02/speeding-up-elixir-project-build-times-on-travis-ci