### PR TITLE
Ecto migrations

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -8,6 +8,7 @@
     "test/support/model_case.ex",
     "test/support/channel_case.ex",
     "web/web.ex",
-    "web/views"
+    "web/views",
+    "web/models"
   ]
 }

--- a/priv/repo/migrations/20170729161949_create_repository.exs
+++ b/priv/repo/migrations/20170729161949_create_repository.exs
@@ -1,0 +1,13 @@
+defmodule Tudo.Repo.Migrations.CreateRepository do
+  use Ecto.Migration
+
+  def change do
+    create table(:repositories) do
+      add :name, :string
+      add :url, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20170729162010_create_issue.exs
+++ b/priv/repo/migrations/20170729162010_create_issue.exs
@@ -1,0 +1,21 @@
+defmodule Tudo.Repo.Migrations.CreateIssue do
+  use Ecto.Migration
+
+  def change do
+    create table(:issues) do
+      add :title, :string
+      add :url, :string
+      add :labels, {:array, :string}
+      add :gh_created_at, :date
+      add :gh_updated_at, :date
+      add :comments_number, :integer
+      add :state, :string
+      add :assignees, {:array, :string}
+      add :repository_id, references(:repositories, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:issues, [:repository_id])
+
+  end
+end

--- a/test/models/issue_test.exs
+++ b/test/models/issue_test.exs
@@ -1,0 +1,18 @@
+defmodule Tudo.IssueTest do
+  use Tudo.ModelCase
+
+  alias Tudo.Issue
+
+  @valid_attrs %{assignees: [], comments_number: 42, gh_created_at: %{day: 17, month: 4, year: 2010}, gh_updated_at: %{day: 17, month: 4, year: 2010}, labels: [], state: "some content", title: "some content", url: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Issue.changeset(%Issue{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Issue.changeset(%Issue{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/repository_test.exs
+++ b/test/models/repository_test.exs
@@ -1,0 +1,18 @@
+defmodule Tudo.RepositoryTest do
+  use Tudo.ModelCase
+
+  alias Tudo.Repository
+
+  @valid_attrs %{name: "some content", url: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Repository.changeset(%Repository{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Repository.changeset(%Repository{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/web/models/issue.ex
+++ b/web/models/issue.ex
@@ -1,0 +1,30 @@
+defmodule Tudo.Issue do
+  use Tudo.Web, :model
+  @moduledoc false
+
+  schema "issues" do
+    field :title, :string
+    field :url, :string
+    field :labels, {:array, :string}
+    field :gh_created_at, Ecto.Date
+    field :gh_updated_at, Ecto.Date
+    field :comments_number, :integer
+    field :state, :string
+    field :assignees, {:array, :string}
+    belongs_to :repository, Tudo.Repository
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  @fields [:title, :url, :labels, :gh_created_at, :gh_updated_at,
+           :comments_number, :state, :assignees]
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @fields)
+    |> validate_required(@fields)
+  end
+end

--- a/web/models/repository.ex
+++ b/web/models/repository.ex
@@ -1,0 +1,21 @@
+defmodule Tudo.Repository do
+  use Tudo.Web, :model
+  @moduledoc false
+
+  schema "repositories" do
+    field :name, :string
+    field :url, :string
+    has_many :issues, Tudo.Issue
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :url])
+    |> validate_required([:name, :url])
+  end
+end


### PR DESCRIPTION
#149 #165 
- adds ecto migrations for issues and repositories

We ran:
```
mix phoenix.gen.model Repository repositories name:string url:string
mix phoenix.gen.model Issue issues title url labels:array:string gh_created_at:date gh_updated_at:date comments_number:integer state assignees:array:string repository_id:references:repositories

and mix ecto.migrate
```