### PR TITLE
replaces single quote strings (charlists) with double quote strings

### DIFF
--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -23,8 +23,8 @@ defmodule Tudo.PageView do
     |> String.to_integer(16)
 
     case rgb_value > 0xffffff / 2 do
-      true -> %{label_hex: label_hex, label_name: label_name, font_hex: '#000'}
-      false -> %{label_hex: label_hex, label_name: label_name, font_hex: '#fff'}
+      true -> %{label_hex: label_hex, label_name: label_name, font_hex: "#000"}
+      false -> %{label_hex: label_hex, label_name: label_name, font_hex: "#fff"}
     end
   end
 


### PR DESCRIPTION
Although the code was working before, single quotes shouldn't be used for strings.  :+1:

#222 