### PR TITLE
Adds 'updated' and 'created' timestamps for desktop site

### DIFF
--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -11,6 +11,7 @@
     <thead>
       <tr class="bb bw2 dwyl-b--gray">
         <th class="pv3 pl2">Repo</th>
+        <th class="pv3 pl2">Updated on</th>
         <th class="pv3 pl3">Title</th>
         <th class="pv3">Assignees</th>
       </tr>
@@ -19,6 +20,7 @@
       <%= for issue <- @issues do %>
       <tr class="h2">
         <td class="pl2"><%= issue."repo_name"%></td>
+        <td class="pl2 w4"> <%= issue.gh_updated_at %></td>
         <td class="pl3 b">
           <a href="<%= issue."url"%>" class="link dwyl-dark-gray">
             <%= issue."title"%>
@@ -32,7 +34,7 @@
             <img src="<%= assignee %>" alt="" class="w1plus br2">
           <% end %>
         </td>
-        <td class="w2 f6">
+        <td class="w3 f6">
           <a href="<%= issue."url"%>" class="link dwyl-dark-gray">
             <i class="fa fa-comment-o dwyl-dark-gray" aria-hidden="true"></i>
             <%= issue."comments_number"%>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -11,7 +11,8 @@
     <thead>
       <tr class="bb bw2 dwyl-b--gray">
         <th class="pv3 pl2">Repo</th>
-        <th class="pv3 pl2">Updated on</th>
+        <th class="pv3 pl2">Created</th>
+        <th class="pv3 pl2">Updated</th>
         <th class="pv3 pl3">Title</th>
         <th class="pv3">Assignees</th>
       </tr>
@@ -20,6 +21,7 @@
       <%= for issue <- @issues do %>
       <tr class="h2">
         <td class="pl2"><%= issue."repo_name"%></td>
+        <td class="pl2 w4"> <%= issue.gh_created_at %></td>
         <td class="pl2 w4"> <%= issue.gh_updated_at %></td>
         <td class="pl3 b">
           <a href="<%= issue."url"%>" class="link dwyl-dark-gray">

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -10,9 +10,9 @@
   <table class="w-80 center dn db-ns">
     <thead>
       <tr class="bb bw2 dwyl-b--gray">
-        <th><%= sort_link @conn, @rummage, [field: :repo_name, name: "Repo"] %></th>
-        <th><%= sort_link @conn, @rummage, [field: :gh_created_at, name: "Created"] %></th>
-        <th><%= sort_link @conn, @rummage, [field: :gh_updated_at, name: "Updated"] %></th>
+        <th><%= sort_link @conn, @rummage, field: :repo_name, name: "Repo" %></th>
+        <th><%= sort_link @conn, @rummage, field: :gh_created_at, name: "Created" %></th>
+        <th><%= sort_link @conn, @rummage, field: :gh_updated_at, name: "Updated" %></th>
         <th class="pv3 pl3">Title</th>
         <th class="pv3">Assignees</th>
       </tr>
@@ -48,13 +48,13 @@
   </table>
   <div class="dn-ns tc">
     <div class="p3">
-      Sort by: <%= sort_link @conn, @rummage, [field: :repo_name, name: "Repo"] %>,
-      <%= sort_link @conn, @rummage, [field: :gh_created_at, name: "Created"] %>,
-      <%= sort_link @conn, @rummage, [field: :gh_updated_at, name: "Updated"] %>
+      Sort by: <%= sort_link @conn, @rummage, field: :repo_name, name: "Repo" %>,
+      <%= sort_link @conn, @rummage, field: :gh_created_at, name: "Created" %>,
+      <%= sort_link @conn, @rummage, field: :gh_updated_at, name: "Updated" %>
     </div>
     <%= for issue <- @issues do %>
       <%= component("issue_card", issue: issue, labels: get_label_data(issue) ) %>
     <% end %>
-  </>
+  </div>
 </section>
 <%= pagination_link(@conn, @rummage) %>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -10,9 +10,9 @@
   <table class="w-80 center dn db-ns">
     <thead>
       <tr class="bb bw2 dwyl-b--gray">
-        <th class="pv3 pl2">Repo</th>
-        <th class="pv3 pl2">Created</th>
-        <th class="pv3 pl2">Updated</th>
+        <th><%= sort_link @conn, @rummage, [field: :issues, name: "Repo"] %></th>
+        <th><%= sort_link @conn, @rummage, [field: :gh_created_at, name: "Created"] %></th>
+        <th><%= sort_link @conn, @rummage, [field: :gh_updated_at, name: "Updated"] %></th>
         <th class="pv3 pl3">Title</th>
         <th class="pv3">Assignees</th>
       </tr>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -10,7 +10,7 @@
   <table class="w-80 center dn db-ns">
     <thead>
       <tr class="bb bw2 dwyl-b--gray">
-        <th><%= sort_link @conn, @rummage, [field: :issues, name: "Repo"] %></th>
+        <th><%= sort_link @conn, @rummage, [field: :repo_name, name: "Repo"] %></th>
         <th><%= sort_link @conn, @rummage, [field: :gh_created_at, name: "Created"] %></th>
         <th><%= sort_link @conn, @rummage, [field: :gh_updated_at, name: "Updated"] %></th>
         <th class="pv3 pl3">Title</th>
@@ -47,9 +47,14 @@
     </tbody>
   </table>
   <div class="dn-ns tc">
+    <div class="p3">
+      Sort by: <%= sort_link @conn, @rummage, [field: :repo_name, name: "Repo"] %>,
+      <%= sort_link @conn, @rummage, [field: :gh_created_at, name: "Created"] %>,
+      <%= sort_link @conn, @rummage, [field: :gh_updated_at, name: "Updated"] %>
+    </div>
     <%= for issue <- @issues do %>
       <%= component("issue_card", issue: issue, labels: get_label_data(issue) ) %>
     <% end %>
-  </div>
+  </>
 </section>
 <%= pagination_link(@conn, @rummage) %>


### PR DESCRIPTION
The mobile site shows created/updated but the desktop doesn't.
Also adds sort by links for repo, updated and created. Fixes #227 
fixes #225 