### PR TITLE
adds test files to lint script

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -19,8 +19,8 @@
         #
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
-        included: ["src/", "web/", "apps/"],
-        excluded: [~r"/_build/", ~r"/deps/"]
+        included: ["src/", "web/", "apps/", "test/"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/test/support/"]
       },
       #
       # If you create your own checks, you must specify the source files for

--- a/test/controllers/hook_controller_test.exs
+++ b/test/controllers/hook_controller_test.exs
@@ -39,7 +39,8 @@ defmodule Tudo.HookControllerTest do
       issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
       assert issue == default_issue
-      assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+      assert json_response(conn, 200) ==
+        ~s({"errors": 0, "message": "thankyou"}\n)
     end)
   end
 
@@ -57,7 +58,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.title == "New Title"
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue comment is created", %{conn: conn} do
@@ -74,7 +76,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.comments_number == 1
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue comment is deleted", %{conn: conn} do
@@ -91,7 +94,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.comments_number == 0
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue is closed", %{conn: conn} do
@@ -106,7 +110,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.state == "closed"
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue is reopened :: not in db", %{conn: conn} do
@@ -125,7 +130,8 @@ defmodule Tudo.HookControllerTest do
 
     assert issue.title == "Reopened issue"
     assert issue.labels == ["#009800;help wanted"]
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue is reopened :: already in db", %{conn: conn} do
@@ -149,7 +155,8 @@ defmodule Tudo.HookControllerTest do
 
     assert issue != default_issue
     assert issue == %{default_issue | state: "open"}
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue has label added :: not in db", %{conn: conn} do
@@ -168,7 +175,8 @@ defmodule Tudo.HookControllerTest do
 
     assert issue.title == "Labeled issue"
     assert issue.labels == ["#009800;help wanted"]
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue has label added :: already in db", %{conn: conn} do
@@ -192,7 +200,8 @@ defmodule Tudo.HookControllerTest do
 
     assert issue != default_issue
     assert issue == %{default_issue | labels: ["#009800;help wanted"]}
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue has label removed", %{conn: conn} do
@@ -207,7 +216,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.labels == []
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue has an assignee added", %{conn: conn} do
@@ -223,7 +233,8 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.assignees == ["shouston3;https://avatars3.githubusercontent.com/u/15983736?v=4&u=8b6cfb76f2bf2c65dc0b215e179abe1d4cf9c42a&s=400"]
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 
   test "issue has an assignee removed", %{conn: conn} do
@@ -239,6 +250,7 @@ defmodule Tudo.HookControllerTest do
     issue = Repo.get_by! Issue, url: "#{@gh_prefix}/issues/1"
 
     assert issue.assignees == []
-    assert json_response(conn, 200) == ~s({"errors": 0, "message": "thankyou"}\n)
+    assert json_response(conn, 200) ==
+      ~s({"errors": 0, "message": "thankyou"}\n)
   end
 end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -2,21 +2,21 @@ defmodule Tudo.PageControllerTest do
   use Tudo.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get(conn, "/", %{"rummage" => %{"paginate" => %{},"search" => %{},"sort" => %{}}})
+    conn = get(conn, "/", %{"rummage" => %{"paginate" => %{}, "search" => %{}, "sort" => %{}}})
     assert html_response(conn, 200) =~ "Help Wanted"
   end
 
   test "GET / with params", %{conn: conn} do
     params =
-      %{"rummage" => %{ "paginate" => %{}, "search" => %{}, "sort" => %{} },
-        "search" => "time" }
+      %{"rummage" => %{"paginate" => %{}, "search" => %{}, "sort" => %{}},
+        "search" => "time"}
 
     conn = get conn, "/", params
     assert html_response(conn, 200) =~ "Help Wanted"
   end
 
   test "POST /", %{conn: conn} do
-    conn = get(conn, "/search", %{"issue" => %{"repo_name" => "hello"}} )
+    conn = get(conn, "/search", %{"issue" => %{"repo_name" => "hello"}})
     assert html_response(conn, 302) =~ "redirected"
   end
 

--- a/test/models/issue_test.exs
+++ b/test/models/issue_test.exs
@@ -3,7 +3,17 @@ defmodule Tudo.IssueTest do
 
   alias Tudo.Issue
 
-  @valid_attrs %{assignees: [], comments_number: 42, gh_created_at: %{day: 17, month: 4, year: 2010}, gh_updated_at: %{day: 17, month: 4, year: 2010}, labels: [], repo_name: "some content", state: "some content", title: "some content", url: "some content"}
+  @valid_attrs %{
+      assignees: [],
+      comments_number: 42,
+      gh_created_at: %{day: 17, month: 4, year: 2010},
+      gh_updated_at: %{day: 17, month: 4, year: 2010},
+      labels: [],
+      repo_name: "some content",
+      state: "some content",
+      title: "some content",
+      url: "some content"
+    }
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/models/user_from_auth_test.exs
+++ b/test/models/user_from_auth_test.exs
@@ -25,4 +25,3 @@ defmodule Tudo.UserFromAuthTest do
     assert info.name == "eoin mc"
   end
 end
-

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
 ExUnit.start
 
 Ecto.Adapters.SQL.Sandbox.mode(Tudo.Repo, :manual)
-


### PR DESCRIPTION
Adds test directory to the .credo.exs and ignores the `test/support/`
Also edits the files in the test directory so they pass the linter. 
fixes #239