### PR TITLE
adds links to assignee's github profiles

### DIFF
--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -53,7 +53,9 @@
         </td>
         <td class="tc">
           <%= for assignee <- generate_avatar(issue) do %>
-            <img src="https://www.github.com/<%= assignee %>.png" alt="<%= assignee %>'s github avatar'" class="w1plus br2">
+            <a href="https://www.github.com/<%= assignee %>" title="<%= assignee %>">
+              <img src="https://www.github.com/<%= assignee %>.png" alt="<%= assignee %>'s github avatar'" class="w1plus br2">
+            </a>
           <% end %>
         </td>
         <td class="w3 f6">


### PR DESCRIPTION
Turns the assignee images into links to the assignee's github profile, and makes it to that when the cursor hovers an assignee's image, the assignee's github username shows.

fix #245