### PR TITLE
Fix autocomplete oddity bug

### DIFF
--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -14,11 +14,9 @@
 
       <label for="repo-search" class="black f4">Repo: </label>
       <select class="" name="issue[repo_name]" id="repo-search">
-        <option value=""></option> 
+        <option value=""></option>
           <%= for repo_name <- @repos do %>
-            <option value="<%= repo_name %>">
-              <%= repo_name %>
-            </option>
+            <option value="<%= repo_name %>"><%= repo_name %></option>
           <% end %>
       </select>
 


### PR DESCRIPTION
As detailed in #248 the autocomplete is behaving oddly, this was due to a line break in between the `option` tag and the contents, which was interpreted as part of the text. I've removed the line break (which makes the code look uglier :cry:) which fixes everything.
fix #248 