### PR TITLE
Clean success / fail messages from the seed file

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,4 +1,4 @@
-alias Tudo.{Hook, GithubApi, Issue, Repo}
+alias Tudo.{GithubApi, Issue, Repo, Hook}
 
 # Copying parrallel map idea from here:
 # http://elixir-recipes.github.io/concurrency/parallel-map/
@@ -14,7 +14,7 @@ GithubApi.get_repos("dwyl")
         Hook.create "dwyl/#{repo}", hook_endpoint
       end)
       issue_task = Task.async(fn ->
-        GithubApi.get_help_wanted_issues("dwyl/#{repo}")
+        GithubApi.get_all_issues("dwyl/#{repo}")
       end)
 
       Task.await(hook_task, timeout)
@@ -23,13 +23,21 @@ GithubApi.get_repos("dwyl")
   end)
 |> Enum.map(&Task.await(&1, timeout))
 |> List.flatten
+|> Enum.filter(&GithubApi.help_wanted_or_no_labels?/1)
 |> Enum.map(&GithubApi.format_data/1)
-|> Enum.each(fn (%{"url" => html_url} = issue) ->
+|> Enum.reduce([0, 0], fn (%{"url" => html_url} = issue, [inserted, duplicate]) ->
     unless Repo.get_by(Issue, url: html_url) do
       %Issue{}
       |> Issue.changeset(issue)
       |> Repo.insert!
+
+      [inserted + 1, duplicate]
     else
-      IO.puts "issue already exists in DB: #{issue["title"] }"
+      [inserted, duplicate + 1]
     end
   end)
+|> (fn [inserted, duplicate] ->
+    IO.puts "#{inserted} issues added to the database"
+    if duplicate > 0, do:
+      IO.puts "#{duplicate} issues not inserted because they already exist in the database."
+  end).()


### PR DESCRIPTION
Adds IO.puts to the seed file to show the total number of issues added, as well as the number of issues not added due to already being in the db.

#251