### PR TITLE
Makes help wanted logo a link

### DIFF
--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,6 +1,6 @@
 <header class="">
-  <div class="tc"><img class="w-20-ns w-50"src="https://user-images.githubusercontent.com/7805691/28775786-b7de0678-75eb-11e7-9dea-54dd674834ef.png"/></div>
-  <div class="f6 pa2 tc">
+  <a class="tc db" href="<%= page_path(@conn, :index) %>"><img class="w-20-ns w-50"src="https://user-images.githubusercontent.com/7805691/28775786-b7de0678-75eb-11e7-9dea-54dd674834ef.png" alt="help wanted logo"/></a>
+  <div class="f5 pa2 tc w-80 center">
     <p class=""> Help Wanted is a dwyl product, made with ❤️ , so that you can easily contribute to open source projects. Each of the issues below requires help from someone like you; technical or not.</p>
     <p class=""> Take a look at our <a href="https://github.com/dwyl/labels#labels" target="_blank">labels repo</a> to familiarise yourself with what they mean and if you want to learn more about how to contribute to dwyl repos, check out our <a href="https://github.com/dwyl/contributing" target="_blank">contributing guide</a>.</p>
     <p class="">We'll be adding features over time based on your recommendations so please leave us feedback through an issue and apply the <code>enhancement</code> label.</p>


### PR DESCRIPTION
The help wanted logo is now a link to the home page, and has some alt text to make it more accessible.
fix #255