### PR TITLE
Fixes the default sort to display the most recent issues

### DIFF
--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -12,10 +12,10 @@ defmodule Tudo.PageController do
        params["rummage"]
       )
 
+    initial_rummage = IssueSorting.default_sort_by(initial_rummage)
+
     {issues, rummage} =
       IssueSorting.collect_issues(search_params, initial_rummage)
-
-    rummage = IssueSorting.default_sort_by(rummage)
 
     render conn,
       "index.html",


### PR DESCRIPTION
Fixes a bug that stopped the most recent issues from being shown on the home page.

#260 